### PR TITLE
Syntax file seemed to be missing dollar-quoting, which this adds

### DIFF
--- a/syntax/pgsql.vim
+++ b/syntax/pgsql.vim
@@ -54,6 +54,7 @@ syn keyword pgsqlSpecial	 false null true
 " Strings (single- and double-quote)
 syn region pgsqlString		 start=+"+  skip=+\\\\\|\\"+  end=+"+
 syn region pgsqlString		 start=+'+  skip=+\\\\\|\\'+  end=+'+
+syn region pgsqlString		 start=+\$\z(\w*\)\$+  end=+\$\z1\$+
 
 " Numbers and hexidecimal values
 syn match pgsqlNumber		 "-\=\<[0-9]*\>"


### PR DESCRIPTION
The \z stuff is apparently necessary to make backreferences work in syntax regions.
That's based on nothing more than what the internet says, but it seems to work.
